### PR TITLE
enhanced text input components, added simple button component

### DIFF
--- a/src/dev/splunk_ui_cljs/stories/button_stories.cljs
+++ b/src/dev/splunk_ui_cljs/stories/button_stories.cljs
@@ -1,0 +1,36 @@
+(ns splunk-ui-cljs.stories.button-stories
+  (:require
+   [reagent.core :as r]
+   ["@splunk/themes" :refer [SplunkThemeProvider]]
+   [splunk-ui-cljs.stories.utils :as utils]
+   [splunk-ui-cljs.button :refer [button]]))
+
+
+(def ^:export default
+  (utils/->default
+   {:title     "Button"
+    :component button
+    :argTypes  {:label      {:control "text"}
+                :appearance {:control "select"
+                             :options ["default", "secondary", "primary", "destructive", "pill", "toggle", "flat"]}
+                :disabled   {:control "radio"
+                             :options [true false]}}}))
+
+
+(defn ^:export button-variants [args]
+  (r/as-element
+   [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
+    [:div {:style {:display "flex" :justify-content "space-between"}}
+     [button {:label "default"}]
+     [button {:label      "secondary"
+              :appearance "secondary"}]
+     [button {:label      "primary"
+              :appearance "primary"}]
+     [button {:label      "destructive"
+              :appearance "destructive"}]
+     [button {:label      "pill"
+              :appearance "pill"}]
+     [button {:label      "toggle"
+              :appearance "toggle"}]
+     [button {:label      "flat"
+              :appearance "flat"}]]]))

--- a/src/dev/splunk_ui_cljs/stories/input_text_stories.cljs
+++ b/src/dev/splunk_ui_cljs/stories/input_text_stories.cljs
@@ -1,14 +1,15 @@
 (ns splunk-ui-cljs.stories.input-text-stories
-  (:require [reagent.core :as r]
-            ["@splunk/themes" :refer [SplunkThemeProvider]]
-            [splunk-ui-cljs.stories.utils :as utils]
-            [splunk-ui-cljs.input-text :refer [input-text]]))
+  (:require
+   [reagent.core :as r]
+   ["@splunk/themes" :refer [SplunkThemeProvider]]
+   [splunk-ui-cljs.stories.utils :as utils]
+   [splunk-ui-cljs.input-text :as inputs]))
 
 
 (def ^:export default
   (utils/->default
    {:title     "Input text"
-    :component input-text
+    :component inputs/input-text
     :argTypes  {:placeholder {:control "text"}
                 :width       {:control "number"}}}))
 
@@ -17,20 +18,48 @@
   (js/console.log new-value))
 
 
-(defn ^:export input-text-normal [args]
+(defn ^:export input-text [args]
   (let [params (-> args utils/->params)]
     (r/as-element
      [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
-      [input-text (merge {:on-change   on-change
-                          :placeholder "simple input"}
-                         params)]])))
+      [inputs/input-text (merge {:on-change   on-change
+                                 :placeholder "simple input"}
+                                params)]])))
 
 
 (defn ^:export input-text-custom-width [args]
   (let [params (-> args utils/->params)]
     (r/as-element
      [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
-      [input-text (merge {:on-change   on-change
-                          :placeholder "input with custom width"
-                          :width       400}
-                         params)]])))
+      [inputs/input-text (merge {:on-change   on-change
+                                 :placeholder "input with custom width"
+                                 :width       400}
+                                params)]])))
+
+
+(defn ^:export input-text-regex-validation [args]
+  (let [params (-> args utils/->params)]
+    (r/as-element
+     [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
+      [inputs/input-text (merge {:on-change        on-change
+                                 :placeholder      "only 1 is allowed"
+                                 :validation-regex #"^1+$"}
+                                params)]])))
+
+
+(defn ^:export input-password [args]
+  (let [params (-> args utils/->params)]
+    (r/as-element
+     [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
+      [inputs/input-password (merge {:on-change   on-change
+                                     :placeholder "type password"}
+                                    params)]])))
+
+
+(defn ^:export input-textarea [args]
+  (let [params (-> args utils/->params)]
+    (r/as-element
+     [:> SplunkThemeProvider {:family "prisma" :colorScheme "light"}
+      [inputs/input-textarea (merge {:on-change on-change
+                                     :rows      4}
+                                    params)]])))

--- a/src/main/splunk_ui_cljs/button.cljs
+++ b/src/main/splunk_ui_cljs/button.cljs
@@ -1,1 +1,17 @@
-(ns splunk-ui-cljs.button)
+(ns splunk-ui-cljs.button
+  (:require
+   [reagent.core :as r]
+   ["@splunk/react-ui/Button" :default Button]))
+
+
+(def button-base
+  (r/adapt-react-class Button))
+
+
+(defn button [{:keys [label appearance disabled on-click]
+               :or   {appearance "default"}}]
+  [button-base
+   {:label      label
+    :appearance appearance
+    :disabled   disabled
+    :onClick    on-click}])

--- a/src/main/splunk_ui_cljs/core.cljs
+++ b/src/main/splunk_ui_cljs/core.cljs
@@ -1,9 +1,14 @@
 (ns splunk-ui-cljs.core
   (:require
-   [splunk-ui-cljs.input-text :as input-text]
-   [splunk-ui-cljs.line :as line]))
+   [splunk-ui-cljs.input-text :as splunk.input-text]
+   [splunk-ui-cljs.line :as splunk.line]
+   [splunk-ui-cljs.button :as splunk.button]))
 
 
-(def input-text input-text/input-text)
-(def input-password input-text/input-password)
-(def line line/line)
+(def input-text splunk.input-text/input-text)
+(def input-password splunk.input-text/input-password)
+(def input-textarea splunk.input-text/input-textarea)
+
+(def line splunk.line/line)
+
+(def button splunk.button/button)

--- a/src/main/splunk_ui_cljs/input_text.cljs
+++ b/src/main/splunk_ui_cljs/input_text.cljs
@@ -1,10 +1,41 @@
 (ns splunk-ui-cljs.input-text
   (:require
+   ["react" :as react]
+   [reagent.core :as r]
    [cljs-styled-components.reagent :refer-macros [defstyled]]
-   ["@splunk/react-ui/Text" :default Text]))
+   ["@splunk/react-ui/Text" :default Text]
+   ["@splunk/react-ui/TextArea" :default TextArea]))
+
+
+(defn assoc-some
+  "Associates a key k, with a value v in a map m, if and only if v is not nil."
+  ([m k v]
+   (if (nil? v) m (assoc m k v)))
+
+  ([m k v & kvs]
+   (reduce (fn [m [k v]] (assoc-some m k v))
+           (assoc-some m k v)
+           (partition 2 kvs))))
+
+
+(defn model->value
+  "Takes a value or an atom
+   If it's a value, returns it
+   If it's a Reagent object that supports IDeref, returns the value inside it by derefing"
+  [val-or-atom]
+  (if (satisfies? IDeref val-or-atom)
+    @val-or-atom
+    val-or-atom))
 
 
 (defstyled text-base Text
+  {:width #(let [width (unchecked-get % "$width")]
+             (if (number? width)
+               (str width "px")
+               width))})
+
+
+(defstyled textarea-base TextArea
   {:width #(let [width (unchecked-get % "$width")]
              (if (number? width)
                (str width "px")
@@ -16,26 +47,76 @@
    model = r/atom
    on-change = function to deal with state changes
    input-type = type of input (html5) e.g. [text, password]"
-  [{:keys [model on-change input-type disabled?
-           placeholder status width validation-regex]
-    :or   {disabled? false input-type "text"}}]
-  (let [controlled? (some? model)]
-    [text-base (cond-> {:onChange    (fn [e]
-                                       (let [new-val (.. e -target -value)]
-                                         (on-change new-val)))
-                        :placeholder placeholder
-                        :type        input-type
-                        :disabled    disabled?
-                        :error       (= status :error)
-                        :$width      width}
-                       controlled? (assoc :value @model))]))
+  [{:keys [model]}]
+  (let [initial-value  (model->value model)
+        external-state (r/atom initial-value)
+        local-state    (r/atom (if (nil? initial-value) "" initial-value))
+        input-ref      (react/createRef)
+        set-caret      (fn [start end]
+                         (when-let [input-element (.-current input-ref)]
+                           ;; dangerous hack to prevent jumping caret
+                           (js/setTimeout #(.setSelectionRange input-element start end))))]
+    (fn [{:keys [model on-change input-type disabled? placeholder status width validation-regex rows]
+          :or   {disabled? false input-type "text"}}]
+      (let [on-change-handler (fn [new-val]
+                                (reset! local-state new-val)
+
+                                (when (fn? on-change)
+                                  (let [has-done-fn? (= 2 (.-length ^js/Function on-change))
+                                        reset-fn     #(reset! external-state new-val)]
+                                    (if has-done-fn?
+                                      (on-change new-val reset-fn)
+                                      (do (on-change new-val)
+                                          (reset-fn))))))
+            latest-ext-value  (model->value model)
+            textarea?         (= input-type "textarea")
+            base-component    (if textarea? textarea-base text-base)
+            base-props        {:onChange (fn [e]
+                                           (let [new-val (.. e -target -value)]
+                                             (when (or
+                                                    ;; no validation
+                                                    (not validation-regex)
+                                                    ;; allow to clear the input value
+                                                    (= new-val "")
+                                                    ;; has validation and string matches regex
+                                                    (and validation-regex (re-find validation-regex new-val)))
+                                               (let [caret-start (.. e -target -selectionStart)
+                                                     caret-end   (.. e -target -selectionEnd)]
+                                                 (on-change-handler new-val)
+                                                 (set-caret caret-start caret-end)))))
+                               :value    @local-state
+                               :inputRef input-ref
+                               :disabled disabled?
+                               :error    (= status :error)
+                               :$width   width}]
+
+        (when (and (some? latest-ext-value)
+                   (not= @external-state latest-ext-value)) ;; Has model changed externally?
+          (reset! external-state latest-ext-value)
+          (reset! local-state latest-ext-value))
+
+        [base-component (assoc-some base-props
+                          :rowsMin (when textarea? rows)
+                          :placeholder (when-not textarea? placeholder)
+                          :type (when-not textarea? input-type))]))))
 
 
 (defn input-text
   [props]
-  [input-text-base (assoc props :input-type "text")])
+  [input-text-base
+   (assoc props :input-type "text")])
 
 
 (defn input-password
   [props]
-  [input-text-base (assoc props :input-type "password")])
+  [input-text-base
+   (assoc props :input-type "password")])
+
+
+(defn input-textarea
+  [props]
+  [input-text-base
+   (-> props
+       (assoc :input-type "textarea")
+       ;; this prop doesn't make sense for textarea
+       (dissoc :validation-regex))])


### PR DESCRIPTION
- added textarea component
- implemented `validation-regex` logic
- mimic re-com components in the way how they handle change events (input element is always controlled and component has it's own local state synced with external state) 

having a controlled input is always a pain because caret jumps to the end of input after each update. I added a timeout to return caret back to the original position after re-render will finish